### PR TITLE
Preventing a User from RSVP-ing for their own Event

### DIFF
--- a/backend/huddlehub/exceptions.py
+++ b/backend/huddlehub/exceptions.py
@@ -1,0 +1,3 @@
+class InvalidUserAction(Exception):
+    def __init__(self, message="Organizer can't RSVP for their own Event."):
+        super().__init__(message)

--- a/backend/huddlehub/exceptions.py
+++ b/backend/huddlehub/exceptions.py
@@ -1,3 +1,3 @@
-class InvalidUserAction(Exception):
+class InvalidUserActionException(Exception):
     def __init__(self, message="Organizer can't RSVP for their own Event."):
         super().__init__(message)

--- a/backend/huddlehub/exceptions.py
+++ b/backend/huddlehub/exceptions.py
@@ -1,3 +1,6 @@
 class InvalidUserActionException(Exception):
     def __init__(self, message="Organizer can't RSVP for their own Event."):
         super().__init__(message)
+
+    def __str__(self):
+        return f"{self.args[0]}"

--- a/backend/huddlehub/views.py
+++ b/backend/huddlehub/views.py
@@ -139,6 +139,8 @@ def rsvp(request, eventId):
             # remove the RSVP if there exists one
             rsvp.delete()
             print(f"RSVP removed for {request.user.username} for {eventToRSVPFor}")
+
+        # if there doesn't exist an Event, exit this view
         except Event.DoesNotExist:
             print(f"Request event with id {eventId} does not exist")
 

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -11,7 +11,9 @@
             <form action="{% url 'rsvp' eventId=event.id %}" method="post">
               {% csrf_token %}
               {% if user.is_authenticated %}
-                {% if RSVPed %}
+                {% if user == event.organizer  %}
+                  <button class="btn btn-outline-primary disabled">RSVP</button>
+                {% elif RSVPed %}
                   <button class="btn btn-outline-primary">un-RSVP</button>
                 {% else %}
                   <button class="btn btn-primary">RSVP</button>

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -12,7 +12,7 @@
               {% csrf_token %}
               {% if user.is_authenticated %}
                 {% if user == event.organizer  %}
-                  <button class="btn btn-outline-primary disabled">RSVP</button>
+                  <button class="btn btn-primary disabled">RSVP</button>
                 {% elif RSVPed %}
                   <button class="btn btn-outline-primary">un-RSVP</button>
                 {% else %}


### PR DESCRIPTION
# Changes in this PR 

This PR contains changes to prevent a `User` from RSVP-ing for their own `Event`.

## Changes made 

### `index.html` template 

The `RSVP` button will be disabled if the current `User` browsing is the same `User` that organized the `Event`.

```html
{% if user == event.organizer  %}
  <button class="btn btn-primary disabled">RSVP</button>
```

### `rsvp` view 

The `rsvp` view checks if the `User` submitting the request is the same `User` that organized the `Event`. The view does not process any further & returns the `User` to the `index` view.

```python
# throw an Exception if the user tries to RSVP for their own Event
if request.user == organizerOfEventToRSVPFor:
    raise InvalidUserActionException()
```

### Creation of custom `InvalidUserActionException` exception 

A custom `InvalidUserActionException` exception is created to track the invalid `User`'s action of `RSVP`-ing for their own `Event`.

```python
class InvalidUserActionException(Exception):
    def __init__(self, message="Organizer can't RSVP for their own Event."):
        super().__init__(message)

    def __str__(self):
        return f"{self.args[0]}"
```

# Issues closed 

This PR closes #8 
